### PR TITLE
Improved multiple inputs tabs implementation for leaflet widget

### DIFF
--- a/js/draw.js
+++ b/js/draw.js
@@ -1,244 +1,276 @@
 (function ($) {
 
-    Drupal.leaflet_widget = Drupal.leaflet_widget || {};
+  Drupal.leaflet_widget = Drupal.leaflet_widget || {};
 
-    Drupal.behaviors.geofield_widget = {
-        attach: attach
-    };
+  Drupal.behaviors.geofield_widget = {
+    attach: attach
+  };
 
-    function attach(context, settings) {
-        $('.leaflet-widget').once().each(function(i, item) {
-            var id = $(item).attr('id'),
-            options = settings.leaflet_widget_widget[id];
-            if (options.toggle) {
-              $('#' + id + '-input').before('<div class="map btn btn-default" style="cursor: pointer;" id="' + id + '-geojson-toggle">GEOJSON</div>');
-              $('#' + id + '-input').before('<div class="map btn btn-default" style="cursor: pointer;" id="' + id + '-point-toggle">POINT</div></br><input type="text" id="manual-' + id + '-point-input" name="manual-point">');
-                $('#manual-' + id + '-point-input').hide();
-              $('#' + id + '-geojson-toggle').click(function () {
-                $(item).toggle();
-                if ($(this).hasClass('map')) {
-                  $(this).text('Use map');
-                  $(this).removeClass('map');
-                  $('#' + id + '-input').get(0).type = 'text';
+  function attach(context, settings) {
+    $('.leaflet-widget').once().each(function(i, item) {
+      var id = $(item).attr('id'),
+        options = settings.leaflet_widget_widget[id];
 
-                  //Hide select geographic areas if is enable.
-                  if (options.geographic_areas) {
-                    $('.geographic_areas_desc').hide();
-                  }
-                }
-                else {
-                  $(this).text('GEOJSON');
-                  $('#' + id + '-input').get(0).type = 'hidden';
-                  $(this).addClass('map');
+      var map = L.map(id, options.map);
 
-                  //Show select geographic areas if is enable.
-                  if (options.geographic_areas) {
-                    $('.geographic_areas_desc').show();
-                  }
-                }
-              });
+      L.tileLayer(options.map.base_url).addTo(map);
 
-               $('#' + id + '-point-toggle').click(function () {
-                $(item).toggle();
-                $('#manual-' + id + '-point-input').toggle();
+      // Get initial geojson value
+      var current = $('#' + id + '-input').val();
+      current = JSON.parse(current);
+      var layers = Array();
+      if (current.features.length) {
+        var geojson = L.geoJson(current)
+        for (var key in geojson._layers) {
+          layers.push(geojson._layers[key]);
+        }
+      }
 
-                if ($(this).hasClass('map')) {
-                  $(this).text('Use map');
-                  $(this).removeClass('map');
-                  $('#manual-' + id + '-point-input').get(0).type = 'text';
+      var Items = new L.FeatureGroup(layers).addTo(map);
 
-                  //Hide select geographic areas if is enable.
-                  if (options.geographic_areas) {
-                    $('.geographic_areas_desc').hide();
-                  }
-                }
-                else {
-                  $(this).text('POINT');
-                  $('#' + id + '-input').get(0).type = 'hidden';
-                  $(this).addClass('map');
-                  var point_string = $('#manual-' + id + '-point-input').val();
+      // Autocenter if that's cool.
+      if (options.map.auto_center) {
+        if (current.features.length) {
+          map.fitBounds(Items.getBounds());
+        }
+      }
 
-                  if (point_string) {
-                      var point_array = point_string.split(',');
-                      var geojsonFeature = {
-                        "type": "Feature",
-                        "properties": {},
-                        "geometry": {
-                            "type": "Point",
-                            "coordinates": [point_array[0], point_array[1]]
-                        }
-                    };
-                    L.geoJson(geojsonFeature).addTo(map);
-                    leafletWidgetFormWrite(map._layers, id);
-                  }
+      // Add controles to the map
+      var drawControl = new L.Control.Draw({
+        autocenter: true,
+        draw: {
+          position: 'topleft',
+          polygon: options.draw.tools.polygon,
+          circle: options.draw.tools.circle,
+          marker: options.draw.tools.marker,
+          rectangle: options.draw.tools.rectangle,
+          polyline: options.draw.tools.polyline
+        },
+        edit: {
+          featureGroup: Items
+        }
+      });
 
-                  //Show select geographic areas if is enable.
-                  if (options.geographic_areas) {
-                    $('.geographic_areas_desc').show();
-                  }
-                }
-              });
+      map.addControl(drawControl);
 
-            }
-            if (options.geographic_areas) {
-              var json_data = {};
-              var selectList = "<div class='geographic_areas_desc'><p></br>Select a state to add into the map:</p><select id='geographic_areas' name='area'>";
-              selectList += "<option value='0'>" + Drupal.t('-none-') + "</option>";
+      map.on('draw:created', function (e) {
+        var type = e.layerTypee,
+          layer = e.layer;
+        // Remove already created layers. We only want to save one
+        // per field.
+        leafletWidgetLayerRemove(map._layers, Items);
+        // Add new layer.
+        Items.addLayer(layer);
+      });
 
-              for (i = 0; i < options.areas.length; i++) {
-                json_data = jQuery.parseJSON(options.areas[i]);
-                $.each(json_data.features, function (index, item) {
-                    selectList += "<option value='" + item.id + "'>" + item.properties.name + "</option>";
-                });
-              }
-              selectList += "</select></div></br>";
-              $('#' + id + '-input').before(selectList);
+      $(item).parents('form').submit(function(event){
+        if ($('#' + id + '-toggle').hasClass('map')) {
+          leafletWidgetFormWrite(map._layers, id)
+        }
+      });
 
-              $('#geographic_areas').change(function() {
-                var area = $(this).val();
+      Drupal.leaflet_widget[id] = map;
 
-                for (i = 0; i < options.areas.length; i++) {
-                  json_data = jQuery.parseJSON(options.areas[i]);
-                  $.each(json_data.features, function (index, item) {
-                    if (item.id == area) {
-                      L.geoJson(item).addTo(map);
-                      leafletWidgetFormWrite(map._layers, id);
-                    }
-                  });
-                }
-              });
-            }
-            var map = L.map(id, options.map);
+      if (options.toggle) {
+        $('#' + id).before('<ul class="ui-tabs-nav leaflet-widget">' +
+                           '<li><a href="#' + id + '">Map</a></li>' +
+                           '<li><a href="#' + id + '-geojson' + '">GeoJSON</a></li>' +
+                           '<li><a href="#' + id + '-points' + '">Points</a></li>' +
+                           '</ul>');
 
-            L.tileLayer(options.map.base_url).addTo(map);
+        $('#' + id).after('<div id="' + id + '-geojson">' +
+                          '<label for="' + id + '-geojson-textarea">' + Drupal.t('Enter GeoJSON:') + '</label>' +
+                          '<textarea class="text-full form-control form-textarea" id="' + id + '-geojson-textarea" cols="60" rows="10"></textarea>' +
+                          '</div>');
 
-            var current = $('#' + id + '-input').val();
-            current = JSON.parse(current);
-            var layers = Array();
-            if (current.features.length) {
-              var geojson = L.geoJson(current)
-              for (var key in geojson._layers) {
-                layers.push(geojson._layers[key]);
-               }
-            }
+        // Set placeholder
+        $('#' + id + '-geojson-textarea').attr('placeholder', JSON.stringify({"type":"FeatureCollection","features":[]}));
 
-            var Items = new L.FeatureGroup(layers).addTo(map);
-            // Autocenter if that's cool.
-            if (options.map.auto_center) {
+        // Update field's input when geojson input is updated.
+        // @TODO validate before sync
+        $('#' + id + '-geojson-textarea').on('input', function(e) {
+          if(!$('#' + id + '-geojson-textarea').val()) {
+            $('#' + id + '-input').val(JSON.stringify({"type":"FeatureCollection","features":[]}));
+          } else {
+            $('#' + id + '-input').val($('#' + id + '-geojson-textarea').val());
+          }
+        });
+
+        $('#' + id).after('<div id="' + id + '-points" class="">' +
+                          '<label for="' + id + '-points">' + Drupal.t('Point') + '</label>' +
+                          '<input class="text-full form-control form-text" type="text" id="' + id + '-points-input" " placeholder="longitude,latitude" "size="60" maxlength="255">' +
+                          '</div>');
+
+        // Update field's input when geojson input is updated.
+        $('#' + id + '-points-input').on('input', function(e) {
+          var latlng = L.latLng($('#' + id + '-points-input').val().split(','));
+          var coordinates = LatLngToCoords(latlng);
+          var write = JSON.stringify(
+            {"type":"FeatureCollection","features":[{"type":"Feature","geometry":{"type":"Point","coordinates":coordinates},"properties":[]}]}
+          );
+          $('#' + id + '-input').val(write);
+        });
+
+        // Set parent as JQuery UI element and update on selection
+        $('#' + id).parent().tabs({
+          // Default tab is the map tab.
+          selected: 0,
+          select: function(event, ui){
+            switch(ui.index) {
+              case 0:
+                // Map tab is selected
+                // Clear previous layers
+                leafletWidgetLayerRemove(map._layers, Items);
+              var current = $('#' + id + '-input').val();
+              current = JSON.parse(current);
               if (current.features.length) {
+                var geojson = L.geoJson(current)
+                for (var key in geojson._layers) {
+                  // Add new layer.
+                  Items.addLayer(geojson._layers[key]);
+                }
                 map.fitBounds(Items.getBounds());
               }
+              break;
+
+              case 1:
+                // GeoJSON tab is selected
+                // Sync from field's input
+                $('#' + id + '-geojson-textarea').val($('#' + id + '-input').val());
+              break;
+
+              case 2:
+                // Points tab is selected
+                // Reset value and error message and classes (if any).
+                $('#' + id + '-points-input').val('');
+                $('#' + id + '-points-input').parent().removeClass('has-error');
+              $('#' + id + '-points-input').prop('disabled', false)
+              .removeClass('error');
+              $('#' + id + '-points .help-block').remove();
+
+              var current = $('#' + id + '-input').val();
+              current = JSON.parse(current);
+              // Make this unavailable if more then single point.
+              if (current.features.length == 0) {
+                // Empty. Nothing to do
+              } else if (current.features.length == 1
+                  && current.features[0].geometry.type == 'Point') {
+                    $('#' + id + '-points-input').val(current.features[0].geometry.coordinates.toString());
+                  } else {
+                    $('#' + id + '-points-input').parent().addClass('has-error');
+                    $('#' + id + '-points-input').prop('disabled', true)
+                    .addClass('error')
+                    .after('<span class="help-block">Current data cannot be converted to a single point!</span>');
+                  }
+                  break;
             }
-
-            var drawControl = new L.Control.Draw({
-                autocenter: true,
-                draw: {
-                  position: 'topleft',
-                  polygon: options.draw.tools.polygon,
-                  circle: options.draw.tools.circle,
-                  marker: options.draw.tools.marker,
-                  rectangle: options.draw.tools.rectangle,
-                  polyline: options.draw.tools.polyline
-                },
-                edit: {
-                  featureGroup: Items
-                }
-
-              });
-
-              map.addControl(drawControl);
-
-              map.on('draw:created', function (e) {
-                var type = e.layerTypee,
-                  layer = e.layer;
-                // Remove already created layers. We only want to save one
-                // per field.
-                leafletWidgetLayerRemove(map._layers, Items);
-                // Add new layer.
-                Items.addLayer(layer);
-              });
-
-              $(item).parents('form').submit(function(event){
-                if ($('#' + id + '-toggle').hasClass('map')) {
-                  leafletWidgetFormWrite(map._layers, id)
-                }
-              });
-
-            Drupal.leaflet_widget[id] = map;
+          }
         });
-    }
+      }
 
-    /**
-     * Writes layer to input field if there is a layer to write.
-     */
-    function leafletWidgetFormWrite(layers, id) {
-      var write  = Array();
-      for (var key in layers) {
-        if (layers[key]._latlngs || layers[key]._latlng) {
-          write.push(layerToGeometry(layers[key]));
+      if (options.geographic_areas) {
+        var json_data = {};
+        var selectList = "<div class='geographic_areas_desc'><p></br>Select a state to add into the map:</p><select id='geographic_areas' name='area'>";
+        selectList += "<option value='0'>" + Drupal.t('-none-') + "</option>";
+
+        for (i = 0; i < options.areas.length; i++) {
+          json_data = jQuery.parseJSON(options.areas[i]);
+          $.each(json_data.features, function (index, item) {
+            selectList += "<option value='" + item.id + "'>" + item.properties.name + "</option>";
+          });
         }
+
+        selectList += "</select></div></br>";
+        $('#' + id + '-input').before(selectList);
+
+        $('#geographic_areas').change(function() {
+          var area = $(this).val();
+
+          for (i = 0; i < options.areas.length; i++) {
+            json_data = jQuery.parseJSON(options.areas[i]);
+            $.each(json_data.features, function (index, item) {
+              if (item.id == area) {
+                L.geoJson(item).addTo(map);
+                leafletWidgetFormWrite(map._layers, id);
+              }
+            });
+          }
+        });
       }
-      // If no value then provide empty collection.
-      if (!write.length) {
-        write = JSON.stringify({"type":"FeatureCollection","features":[]});
-      }
-      $('#' + id + '-input').val('{"type":"FeatureCollection", "features":[' + write + ']}');
-    }
+    });
+  }
 
-    /**
-     * Removes layers that are already on the map.
-     */
-    function leafletWidgetLayerRemove(layers, Items) {
-      for (var key in layers) {
-        if (layers[key]._latlngs || layers[key]._latlng) {
-          Items.removeLayer(layers[key]);
-        }
-      }
-    }
-
-    // This will all go away once this gets into leaflet main branch:
-    // https://github.com/jfirebaugh/Leaflet/commit/4bc36d4c1926d7c68c966264f3cbf179089bd998
-    var layerToGeometry = function(layer) {
-      var json, type, latlng, latlngs = [], i;
-
-      if (L.Marker && (layer instanceof L.Marker)) {
-        type = 'Point';
-        latlng = LatLngToCoords(layer._latlng);
-        return JSON.stringify({"type": type, "coordinates": latlng});
-
-      } else if (L.Polygon && (layer instanceof L.Polygon)) {
-        type = 'Polygon';
-        latlngs = LatLngsToCoords(layer._latlngs, 1);
-        return JSON.stringify({"type": type, "coordinates": [latlngs]});
-
-      } else if (L.Polyline && (layer instanceof L.Polyline)) {
-        type = 'LineString';
-        latlngs = LatLngsToCoords(layer._latlngs);
-        return JSON.stringify({"type": type, "coordinates": latlngs});
-
+  /**
+   * Writes layer to input field if there is a layer to write.
+   */
+  function leafletWidgetFormWrite(layers, id) {
+    var write  = Array();
+    for (var key in layers) {
+      if (layers[key]._latlngs || layers[key]._latlng) {
+        write.push(layerToGeometry(layers[key]));
       }
     }
-
-    var LatLngToCoords = function (LatLng, reverse) { // (LatLng, Boolean) -> Array
-      var lat = parseFloat(reverse ? LatLng.lng : LatLng.lat),
-        lng = parseFloat(reverse ? LatLng.lat : LatLng.lng);
-
-      return [lng,lat];
+    // If no value then provide empty collection.
+    if (!write.length) {
+      write = JSON.stringify({"type":"FeatureCollection","features":[]});
     }
+    $('#' + id + '-input').val('{"type":"FeatureCollection", "features":[' + write + ']}');
+  }
 
-    var LatLngsToCoords = function (LatLngs, levelsDeep, reverse) { // (LatLngs, Number, Boolean) -> Array
-      var coord,
-        coords = [],
-        i, len;
-
-      for (i = 0, len = LatLngs.length; i < len; i++) {
-          coord = levelsDeep ?
-                  LatLngToCoords(LatLngs[i], levelsDeep - 1, reverse) :
-                  LatLngToCoords(LatLngs[i], reverse);
-          coords.push(coord);
+  /**
+   * Removes layers that are already on the map.
+   */
+  function leafletWidgetLayerRemove(layers, Items) {
+    for (var key in layers) {
+      if (layers[key]._latlngs || layers[key]._latlng) {
+        Items.removeLayer(layers[key]);
       }
-
-      return coords;
     }
+  }
+
+  // This will all go away once this gets into leaflet main branch:
+  // https://github.com/jfirebaugh/Leaflet/commit/4bc36d4c1926d7c68c966264f3cbf179089bd998
+  var layerToGeometry = function(layer) {
+    var json, type, latlng, latlngs = [], i;
+
+    if (L.Marker && (layer instanceof L.Marker)) {
+      type = 'Point';
+      latlng = LatLngToCoords(layer._latlng);
+      return JSON.stringify({"type": type, "coordinates": latlng});
+
+    } else if (L.Polygon && (layer instanceof L.Polygon)) {
+      type = 'Polygon';
+      latlngs = LatLngsToCoords(layer._latlngs, 1);
+      return JSON.stringify({"type": type, "coordinates": [latlngs]});
+
+    } else if (L.Polyline && (layer instanceof L.Polyline)) {
+      type = 'LineString';
+      latlngs = LatLngsToCoords(layer._latlngs);
+      return JSON.stringify({"type": type, "coordinates": latlngs});
+
+    }
+  }
+
+  var LatLngToCoords = function (LatLng, reverse) { // (LatLng, Boolean) -> Array
+    var lat = parseFloat(reverse ? LatLng.lng : LatLng.lat),
+      lng = parseFloat(reverse ? LatLng.lat : LatLng.lng);
+
+    return [lng,lat];
+  }
+
+  var LatLngsToCoords = function (LatLngs, levelsDeep, reverse) { // (LatLngs, Number, Boolean) -> Array
+    var coord,
+    coords = [],
+      i, len;
+
+    for (i = 0, len = LatLngs.length; i < len; i++) {
+      coord = levelsDeep ?
+        LatLngToCoords(LatLngs[i], levelsDeep - 1, reverse) :
+        LatLngToCoords(LatLngs[i], reverse);
+      coords.push(coord);
+    }
+
+    return coords;
+  }
 
 }(jQuery));

--- a/js/draw.js
+++ b/js/draw.js
@@ -104,27 +104,34 @@
     });
 
     $('#' + id).after('<div id="' + id + '-points" class="">' +
-      '<label for="' + id + '-points">' + Drupal.t('Point') + '</label>' +
-      '<input class="text-full form-control form-text" type="text" id="' + id + '-points-input"  placeholder="longitude,latitude" "size="60" maxlength="255"> <a href="#add-point" class="map btn btn-default btn-add-point btn-primary" id="' + id +'-points-add">Add</a>' +
+      '<label for="' + id + '-points">' + Drupal.t('Points') + '</label>' +
+      '<input class="text-full form-control form-text" type="text" id="' + id + '-points-input"  placeholder="longitude,latitude; longitude, latitude; ..." "size="60" maxlength="255"> <a href="#add-point" class="map btn btn-default btn-add-point btn-primary" id="' + id +'-points-add">Add Points</a>' +
     '</div>');
 
   // Update field's input when geojson input is updated.
   $('#' + id + '-points-add').on('click', function(e) {
-    try{
-      var latlng = L.latLng($('#' + id + '-points-input').val().split(','));
-      var coordinates = LatLngToCoords(latlng);
-      var geojsonFeature = {"type":"FeatureCollection","features":[{"type":"Feature","geometry":{"type":"Point","coordinates":coordinates},"properties":[]}]}
-      var write = JSON.stringify(geojsonFeature);
-      var l  = L.geoJson(geojsonFeature).addTo(map);
-      leafletWidgetLayerAdd(l._layers, Items);
-      leafletWidgetFormWrite(map._layers, id);
-      map.fitBounds(Items.getBounds());
-      $('#' + id + '-points-input').val("");
-      map.fitBounds(Items.getBounds());
-    }
-    catch(e) {
-      console.log(e);
-    }
+    var points = $('#' + id + '-points-input').val().split(';');
+    points.forEach(function(point) {
+      if (!point) {
+        return;
+      }
+      try {
+        var latlng = L.latLng(point.split(','));
+        console.log(latlng);
+        var coordinates = LatLngToCoords(latlng);
+        var geojsonFeature = {"type":"FeatureCollection","features":[{"type":"Feature","geometry":{"type":"Point","coordinates":coordinates},"properties":[]}]}
+        var write = JSON.stringify(geojsonFeature);
+        var l  = L.geoJson(geojsonFeature).addTo(map);
+        leafletWidgetLayerAdd(l._layers, Items);
+        leafletWidgetFormWrite(map._layers, id);
+        map.fitBounds(Items.getBounds());
+        $('#' + id + '-points-input').val("");
+        map.fitBounds(Items.getBounds());
+      }
+      catch(e) {
+        console.log(e);
+      }
+    });
   });
 
   // Add tabs.

--- a/js/draw.js
+++ b/js/draw.js
@@ -7,7 +7,7 @@
   };
 
   function attach(context, settings) {
-    $('.leaflet-widget').once().each(function(i, item) {
+    $('.leaflet-container').once('leaflet-container').each(function(i, item) {
       var id = $(item).attr('id'),
         options = settings.leaflet_widget_widget[id];
 

--- a/js/draw.js
+++ b/js/draw.js
@@ -105,7 +105,7 @@
 
     $('#' + id).after('<div id="' + id + '-points" class="">' +
       '<label for="' + id + '-points">' + Drupal.t('Points') + '</label>' +
-      '<input class="text-full form-control form-text" type="text" id="' + id + '-points-input"  placeholder="longitude,latitude; longitude, latitude; ..." "size="60" maxlength="255"> <a href="#add-point" class="map btn btn-default btn-add-point btn-primary" id="' + id +'-points-add">Add Points</a>' +
+      '<input class="text-full form-control form-text" type="text" id="' + id + '-points-input"  placeholder="latitude, longitude;latitude, longitude; ..." "size="60" maxlength="255"> <a href="#add-point" class="map btn btn-default btn-add-point btn-primary" id="' + id +'-points-add">Add Points</a>' +
     '</div>');
 
   // Update field's input when geojson input is updated.

--- a/js/draw.js
+++ b/js/draw.js
@@ -87,7 +87,7 @@
 
       $('#' + id).after('<div id="' + id + '-geojson">' +
         '<label for="' + id + '-geojson-textarea">' + Drupal.t('Enter GeoJSON:') + '</label>' +
-        '<textarea class="text-full form-control form-textarea" id="' + id + '-geojson-textarea" cols="60" rows="10"></textarea>' +
+        '<textarea class="text-full form-control form-textarea" id="' + id + '-geojson-textarea" title="GeoJSON textarea field" cols="60" rows="10"></textarea>' +
       '</div>');
 
     // Set placeholder
@@ -105,7 +105,7 @@
 
     $('#' + id).after('<div id="' + id + '-points" class="">' +
       '<label for="' + id + '-points">' + Drupal.t('Points') + '</label>' +
-      '<input class="text-full form-control form-text" type="text" id="' + id + '-points-input"  placeholder="latitude, longitude;latitude, longitude; ..." "size="60" maxlength="255"> <a href="#add-point" class="map btn btn-default btn-add-point btn-primary" id="' + id +'-points-add">Add Points</a>' +
+      '<input class="text-full form-control form-text" type="text" id="' + id + '-points-input" title="Points text field" placeholder="latitude, longitude;latitude, longitude; ..." "size="60" maxlength="255"> <a href="#add-point" class="map btn btn-default btn-add-point btn-primary" id="' + id +'-points-add">Add Points</a>' +
     '</div>');
 
   // Update field's input when geojson input is updated.

--- a/js/draw.js
+++ b/js/draw.js
@@ -79,9 +79,8 @@
       Drupal.leaflet_widget[id] = map;
 
       if (options.toggle) {
-        var reset_button = '<span class="map btn btn-default" style="cursor: pointer;" id="' + id + '-reset">Reset</span>';
         $('#' + id).before('<ul class="ui-tabs-nav leaflet-widget">' +
-          '<li><a href="#' + id + '">Map</a>'  + reset_button + '</li>' +
+          '<li><a href="#' + id + '">Map</a></li>' +
           '<li><a href="#' + id + '-geojson">GeoJSON</a></li>' +
           '<li><a href="#' + id + '-points">Points</a></li>' +
         '</ul>');

--- a/js/draw.js
+++ b/js/draw.js
@@ -9,7 +9,7 @@
   function attach(context, settings) {
     $('.leaflet-widget').once('leaflet-widget').each(function(i, item) {
       var id = $(item).attr('id'),
-        options = settings.leaflet_widget_widget[id];
+      options = settings.leaflet_widget_widget[id];
 
       var map = L.map(id, options.map);
 
@@ -81,95 +81,95 @@
       if (options.toggle) {
         var reset_button = '<span class="map btn btn-default" style="cursor: pointer;" id="' + id + '-reset">Reset</span>';
         $('#' + id).before('<ul class="ui-tabs-nav leaflet-widget">' +
-                           '<li><a href="#' + id + '">Map</a>'  + reset_button + '</li>' +
-                           '<li><a href="#' + id + '-geojson">GeoJSON</a></li>' +
-                           '<li><a href="#' + id + '-points">Points</a></li>' +
-                           '</ul>');
+          '<li><a href="#' + id + '">Map</a>'  + reset_button + '</li>' +
+          '<li><a href="#' + id + '-geojson">GeoJSON</a></li>' +
+          '<li><a href="#' + id + '-points">Points</a></li>' +
+        '</ul>');
 
-        $('#' + id).after('<div id="' + id + '-geojson">' +
-                          '<label for="' + id + '-geojson-textarea">' + Drupal.t('Enter GeoJSON:') + '</label>' +
-                          '<textarea class="text-full form-control form-textarea" id="' + id + '-geojson-textarea" cols="60" rows="10"></textarea>' +
-                          '</div>');
+      $('#' + id).after('<div id="' + id + '-geojson">' +
+        '<label for="' + id + '-geojson-textarea">' + Drupal.t('Enter GeoJSON:') + '</label>' +
+        '<textarea class="text-full form-control form-textarea" id="' + id + '-geojson-textarea" cols="60" rows="10"></textarea>' +
+      '</div>');
 
-        // Set placeholder
-        $('#' + id + '-geojson-textarea').attr('placeholder', JSON.stringify({"type":"FeatureCollection","features":[]}));
+    // Set placeholder
+    $('#' + id + '-geojson-textarea').attr('placeholder', JSON.stringify({"type":"FeatureCollection","features":[]}));
 
-        // Update field's input when geojson input is updated.
-        // @TODO validate before sync
-        $('#' + id + '-geojson-textarea').on('input', function(e) {
-          if(!$('#' + id + '-geojson-textarea').val()) {
-            $('#' + id + '-input').val(JSON.stringify({"type":"FeatureCollection","features":[]}));
-          } else {
-            $('#' + id + '-input').val($('#' + id + '-geojson-textarea').val());
-          }
-        });
+    // Update field's input when geojson input is updated.
+    // @TODO validate before sync
+    $('#' + id + '-geojson-textarea').on('input', function(e) {
+      if(!$('#' + id + '-geojson-textarea').val()) {
+        $('#' + id + '-input').val(JSON.stringify({"type":"FeatureCollection","features":[]}));
+      } else {
+        $('#' + id + '-input').val($('#' + id + '-geojson-textarea').val());
+      }
+    });
 
-        $('#' + id).after('<div id="' + id + '-points" class="">' +
-                          '<label for="' + id + '-points">' + Drupal.t('Point') + '</label>' +
-                          '<input class="text-full form-control form-text" type="text" id="' + id + '-points-input" " placeholder="longitude,latitude" "size="60" maxlength="255">' +
-                          '</div>');
+    $('#' + id).after('<div id="' + id + '-points" class="">' +
+      '<label for="' + id + '-points">' + Drupal.t('Point') + '</label>' +
+      '<input class="text-full form-control form-text" type="text" id="' + id + '-points-input" " placeholder="longitude,latitude" "size="60" maxlength="255">' +
+    '</div>');
 
-        // Update field's input when geojson input is updated.
-        $('#' + id + '-points-input').on('input', function(e) {
-          try{
-            var latlng = L.latLng($('#' + id + '-points-input').val().split(','));
-            var coordinates = LatLngToCoords(latlng);
-            var geojsonFeature = {"type":"FeatureCollection","features":[{"type":"Feature","geometry":{"type":"Point","coordinates":coordinates},"properties":[]}]}
-            var write = JSON.stringify(geojsonFeature);
+  // Update field's input when geojson input is updated.
+  $('#' + id + '-points-input').on('input', function(e) {
+    try{
+      var latlng = L.latLng($('#' + id + '-points-input').val().split(','));
+      var coordinates = LatLngToCoords(latlng);
+      var geojsonFeature = {"type":"FeatureCollection","features":[{"type":"Feature","geometry":{"type":"Point","coordinates":coordinates},"properties":[]}]}
+      var write = JSON.stringify(geojsonFeature);
 
-            var l  = L.geoJson(geojsonFeature).addTo(map);
-            leafletWidgetLayerAdd(l.layers, Items);
-            leafletWidgetFormWrite(map._layers, id);
-          }
-          catch(e) {
-            console.log(e);
-          }
-        });
+      var l  = L.geoJson(geojsonFeature).addTo(map);
+      leafletWidgetLayerAdd(l.layers, Items);
+      leafletWidgetFormWrite(map._layers, id);
+    }
+    catch(e) {
+      console.log(e);
+    }
+  });
 
-        // Add tabs.
-        $('#' + id).parent().tabs();
+  // Add tabs.
+  $('#' + id).parent().tabs();
 
-        // Map tab is selected
-        // Clear previous layers
-        $('a[href="#' + id + '"]').click(function() {
-          leafletWidgetLayerRemove(map._layers, Items);
-          var current = $('#' + id + '-input').val();
-          current = JSON.parse(current);
-          if (current.features.length) {
-            var geojson = L.geoJson(current)
-            for (var key in geojson._layers) {
-              // Add new layer.
-              Items.addLayer(geojson._layers[key]);
-            }
-            map.fitBounds(Items.getBounds());
-          }
-        });
+  // Map tab is selected
+  // Clear previous layers
+  $('a[href="#' + id + '"]').click(function() {
+    leafletWidgetLayerRemove(map._layers, Items);
+    var current = $('#' + id + '-input').val();
+    current = JSON.parse(current);
+    if (current.features.length) {
+      var geojson = L.geoJson(current)
+      for (var key in geojson._layers) {
+        // Add new layer.
+        Items.addLayer(geojson._layers[key]);
+      }
+      map.fitBounds(Items.getBounds());
+    }
+  });
 
-        // Reset button is selected.
-        // Update field's input when geojson input is updated.
-        $('#' + id + '-reset').click(function () {
-          if ($('div#' + id).is(':visible')) {
-            map.invalidateSize().setView(options.map['center'], options.map['zoom']);
-            leafletWidgetLayerRemove(map._layers, Items);
-            map._layers = Drupal.settings.leaflet_widget_widget[id]['orig_layers'];
-            leafletWidgetFormWrite(layers, id);
-            leafletWidgetLayerAdd(map._layers, Items);
-            if (current.features.length && options.map.auto_center) {
-              map.fitBounds(Items.getBounds());
-            }
-          }
-        });
+  // Reset button is selected.
+  // Update field's input when geojson input is updated.
+  $('#' + id + '-reset').click(function () {
+    if ($('div#' + id).is(':visible')) {
+      map.invalidateSize().setView(options.map['center'], options.map['zoom']);
+      leafletWidgetLayerRemove(map._layers, Items);
+      map._layers = Drupal.settings.leaflet_widget_widget[id]['orig_layers'];
+      leafletWidgetFormWrite(layers, id);
+      leafletWidgetLayerAdd(map._layers, Items);
+      if (current.features.length && options.map.auto_center) {
+        map.fitBounds(Items.getBounds());
+      }
+    }
+  });
 
-        // GeoJSON tab is selected
-        // Sync from field's input
-        $('a[href="#' + id + '-geojson"]').click(function() {
-          $('#' + id + '-geojson-textarea').val($('#' + id + '-input').val());
-        });
+  // GeoJSON tab is selected
+  // Sync from field's input
+  $('a[href="#' + id + '-geojson"]').click(function() {
+    $('#' + id + '-geojson-textarea').val($('#' + id + '-input').val());
+  });
 
-        // Points tab is selected
-        $('a[href="#' + id + '-points"]').click(function() {
-          // Nothing to do.
-        });
+  // Points tab is selected
+  $('a[href="#' + id + '-points"]').click(function() {
+    // Nothing to do.
+  });
 
       }
 
@@ -207,8 +207,8 @@
   }
 
   /**
-   * Writes layer to input field if there is a layer to write.
-   */
+  * Writes layer to input field if there is a layer to write.
+  */
   function leafletWidgetFormWrite(layers, id) {
     var write  = Array();
     for (var key in layers) {
@@ -225,8 +225,8 @@
   }
 
   /**
-   * Filters out layer from input if layer exists.
-   */
+  * Filters out layer from input if layer exists.
+  */
   function leafletWidgetFormDelete(layers, id, layer) {
     var write  = Array();
     for (var key in layers) {
@@ -257,8 +257,8 @@
   }
 
   /**
-   * Removes layers that are already on the map.
-   */
+  * Removes layers that are already on the map.
+  */
   function leafletWidgetLayerRemove(layers, Items) {
     for (var key in layers) {
       if (layers[key]._latlngs || layers[key]._latlng) {
@@ -292,7 +292,7 @@
 
   var LatLngToCoords = function (LatLng, reverse) { // (LatLng, Boolean) -> Array
     var lat = parseFloat(reverse ? LatLng.lng : LatLng.lat),
-      lng = parseFloat(reverse ? LatLng.lat : LatLng.lng);
+    lng = parseFloat(reverse ? LatLng.lat : LatLng.lng);
 
     return [lng,lat];
   }
@@ -300,12 +300,12 @@
   var LatLngsToCoords = function (LatLngs, levelsDeep, reverse) { // (LatLngs, Number, Boolean) -> Array
     var coord,
     coords = [],
-      i, len;
+    i, len;
 
     for (i = 0, len = LatLngs.length; i < len; i++) {
       coord = levelsDeep ?
-        LatLngToCoords(LatLngs[i], levelsDeep - 1, reverse) :
-        LatLngToCoords(LatLngs[i], reverse);
+      LatLngToCoords(LatLngs[i], levelsDeep - 1, reverse) :
+      LatLngToCoords(LatLngs[i], reverse);
       coords.push(coord);
     }
 

--- a/js/draw.js
+++ b/js/draw.js
@@ -61,12 +61,9 @@
         leafletWidgetLayerRemove(map._layers, Items);
         // Add new layer.
         Items.addLayer(layer);
-      });
 
-      $(item).parents('form').submit(function(event){
-        if ($('#' + id + '-toggle').hasClass('map')) {
-          leafletWidgetFormWrite(map._layers, id)
-        }
+        // Update the field input.
+        leafletWidgetFormWrite(Items._layers, id)
       });
 
       Drupal.leaflet_widget[id] = map;
@@ -207,7 +204,8 @@
     var write  = Array();
     for (var key in layers) {
       if (layers[key]._latlngs || layers[key]._latlng) {
-        write.push(layerToGeometry(layers[key]));
+        var feature = '{ "type": "Feature","geometry":' + layerToGeometry(layers[key]) + '}';
+        write.push(feature);
       }
     }
     // If no value then provide empty collection.

--- a/js/draw.js
+++ b/js/draw.js
@@ -7,7 +7,7 @@
   };
 
   function attach(context, settings) {
-    $('.leaflet-widget').once('leaflet-widget').each(function(i, item) {
+    $('div.leaflet-widget').once('leaflet-widget').each(function(i, item) {
       var id = $(item).attr('id'),
       options = settings.leaflet_widget_widget[id];
 

--- a/js/draw.js
+++ b/js/draw.js
@@ -26,6 +26,9 @@
         }
       }
 
+      // Save ORIG layers to use with RESET button.
+      Drupal.settings.leaflet_widget_widget[id]['orig_layers'] = layers;
+
       var Items = new L.FeatureGroup(layers).addTo(map);
 
       // Autocenter if that's cool.
@@ -69,10 +72,11 @@
       Drupal.leaflet_widget[id] = map;
 
       if (options.toggle) {
+        var reset_button = '<span class="map btn btn-default" style="cursor: pointer;" id="' + id + '-reset">Reset</span>';
         $('#' + id).before('<ul class="ui-tabs-nav leaflet-widget">' +
-                           '<li><a href="#' + id + '">Map</a></li>' +
-                           '<li><a href="#' + id + '-geojson' + '">GeoJSON</a></li>' +
-                           '<li><a href="#' + id + '-points' + '">Points</a></li>' +
+                           '<li><a href="#' + id + '">Map</a>'  + reset_button + '</li>' +
+                           '<li><a href="#' + id + '-geojson">GeoJSON</a></li>' +
+                           '<li><a href="#' + id + '-points">Points</a></li>' +
                            '</ul>');
 
         $('#' + id).after('<div id="' + id + '-geojson">' +
@@ -163,7 +167,16 @@
             }
           }
         });
+        $('#' + id + '-reset').click(function () {
+          if ($('div#' + id).is(':visible')) {
+            map.invalidateSize().setView(options.map['center'], options.map['zoom']);
+            leafletWidgetLayerRemove(map._layers, Items);
+            map._layers = Drupal.settings.leaflet_widget_widget[id]['orig_layers'];
+            leafletWidgetLayerAdd(map._layers, Items);
+          }
+        });
       }
+
 
       if (options.geographic_areas) {
         var json_data = {};
@@ -213,6 +226,17 @@
       write = JSON.stringify({"type":"FeatureCollection","features":[]});
     }
     $('#' + id + '-input').val('{"type":"FeatureCollection", "features":[' + write + ']}');
+  }
+
+  /**
+  * Add layers that are already on the map.
+  */
+  function leafletWidgetLayerAdd(layers, Items) {
+    for (var key in layers) {
+      if (layers[key]._latlngs || layers[key]._latlng) {
+        Items.addLayer(layers[key]);
+      }
+    }
   }
 
   /**

--- a/js/draw.js
+++ b/js/draw.js
@@ -7,7 +7,7 @@
   };
 
   function attach(context, settings) {
-    $('.leaflet-container').once('leaflet-container').each(function(i, item) {
+    $('.leaflet-widget').once('leaflet-widget').each(function(i, item) {
       var id = $(item).attr('id'),
         options = settings.leaflet_widget_widget[id];
 

--- a/js/draw.js
+++ b/js/draw.js
@@ -117,8 +117,7 @@
       }
       try {
         var latlng = L.latLng(point.split(','));
-        console.log(latlng);
-        var coordinates = LatLngToCoords(latlng);
+        var coordinates = LatLngToCoords(latlng, true);
         var geojsonFeature = {"type":"FeatureCollection","features":[{"type":"Feature","geometry":{"type":"Point","coordinates":coordinates},"properties":[]}]}
         var write = JSON.stringify(geojsonFeature);
         var l  = L.geoJson(geojsonFeature).addTo(map);

--- a/js/draw.js
+++ b/js/draw.js
@@ -105,20 +105,22 @@
 
     $('#' + id).after('<div id="' + id + '-points" class="">' +
       '<label for="' + id + '-points">' + Drupal.t('Point') + '</label>' +
-      '<input class="text-full form-control form-text" type="text" id="' + id + '-points-input" " placeholder="longitude,latitude" "size="60" maxlength="255">' +
+      '<input class="text-full form-control form-text" type="text" id="' + id + '-points-input"  placeholder="longitude,latitude" "size="60" maxlength="255"> <a href="#add-point" class="map btn btn-default btn-add-point btn-primary" id="' + id +'-points-add">Add</a>' +
     '</div>');
 
   // Update field's input when geojson input is updated.
-  $('#' + id + '-points-input').on('input', function(e) {
+  $('#' + id + '-points-add').on('click', function(e) {
     try{
       var latlng = L.latLng($('#' + id + '-points-input').val().split(','));
       var coordinates = LatLngToCoords(latlng);
       var geojsonFeature = {"type":"FeatureCollection","features":[{"type":"Feature","geometry":{"type":"Point","coordinates":coordinates},"properties":[]}]}
       var write = JSON.stringify(geojsonFeature);
-
       var l  = L.geoJson(geojsonFeature).addTo(map);
-      leafletWidgetLayerAdd(l.layers, Items);
+      leafletWidgetLayerAdd(l._layers, Items);
       leafletWidgetFormWrite(map._layers, id);
+      map.fitBounds(Items.getBounds());
+      $('#' + id + '-points-input').val("");
+      map.fitBounds(Items.getBounds());
     }
     catch(e) {
       console.log(e);
@@ -131,6 +133,9 @@
   // Map tab is selected
   // Clear previous layers
   $('a[href="#' + id + '"]').click(function() {
+    if (!$('div#' + id).is(':visible')) {
+      $('div#' + id).show();
+    }
     leafletWidgetLayerRemove(map._layers, Items);
     var current = $('#' + id + '-input').val();
     current = JSON.parse(current);
@@ -162,14 +167,18 @@
   // GeoJSON tab is selected
   // Sync from field's input
   $('a[href="#' + id + '-geojson"]').click(function() {
+    if ($('div#' + id).is(':visible')) {
+      $('div#' + id).hide();
+    }
     $('#' + id + '-geojson-textarea').val($('#' + id + '-input').val());
   });
 
   // Points tab is selected
   $('a[href="#' + id + '-points"]').click(function() {
-    // Nothing to do.
+    if (!$('div#' + id).is(':visible')) {
+      $('div#' + id).show();
+    }
   });
-
       }
 
 

--- a/leaflet_widget.make
+++ b/leaflet_widget.make
@@ -9,10 +9,10 @@ projects[geophp][subdir] = contrib
 
 libraries[leaflet_draw][type] = libraries
 libraries[leaflet_draw][download][type] = git
-libraries[leaflet_draw][download][url] = "https://github.com/Leaflet/Leaflet.draw.git"
-libraries[leaflet_draw][download][tag] = "v0.2.4"
+libraries[leaflet_draw][download][url] = "https://github.com/NuCivic/Leaflet.draw.git"
+libraries[leaflet_draw][download][tag] = "v0.4.7-civic-4944"
 
 libraries[leaflet_core][type] = libraries
 libraries[leaflet_core][download][type] = git
 libraries[leaflet_core][download][url] = "https://github.com/Leaflet/Leaflet.git"
-libraries[leaflet_core][download][tag] = "v0.7.3"
+libraries[leaflet_core][download][tag] = "v1.0.2"

--- a/leaflet_widget.module
+++ b/leaflet_widget.module
@@ -293,7 +293,7 @@ function leaflet_widget_library() {
     ),
   );
 
-  $leaflet_image_path = $leaflet_core . '/dist/images';
+  $leaflet_image_path = $leaflet_core . '/dist/images/';
   $libraries['leaflet_core'] = array(
     'title' => 'Leaflet (Leaflet Widget)',
     'version' => '1.0.2',

--- a/leaflet_widget.module
+++ b/leaflet_widget.module
@@ -172,6 +172,7 @@ function leaflet_widget_field_widget_form(&$form, &$form_state, $field, $instanc
 
       // Include javascript.
       $widget['#attached']['library'][] = array('leaflet_widget', 'draw');
+      $widget['#attached']['library'][] = array('system', 'ui.tabs');
 
       //Check if we need to add geographic areas
       if (isset($settings['geographic_areas']) && $settings['geographic_areas']) {

--- a/leaflet_widget.module
+++ b/leaflet_widget.module
@@ -335,7 +335,7 @@ function leaflet_widget_geojson_feature($wkt, $properties = array()) {
  */
 function leaflet_widget_leaflet_widget_base_layers() {
   return array(
-    'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png' => 'OSM Mapnik',
+    '//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png' => 'OSM Mapnik',
   );
 }
 

--- a/leaflet_widget.module
+++ b/leaflet_widget.module
@@ -293,6 +293,7 @@ function leaflet_widget_library() {
     ),
   );
 
+  $leaflet_image_path = $leaflet_core . '/dist/images';
   $libraries['leaflet_core'] = array(
     'title' => 'Leaflet (Leaflet Widget)',
     'version' => '0.7.3',
@@ -301,6 +302,7 @@ function leaflet_widget_library() {
     ),
     'js' => array(
       "$leaflet_core/dist/leaflet.js" => array(),
+      'if (!L.Icon.Default.imagePath) L.Icon.Default.imagePath = "/' . $leaflet_image_path . '"' => array('type' => 'inline'),
     ),
   );
 

--- a/leaflet_widget.module
+++ b/leaflet_widget.module
@@ -281,7 +281,7 @@ function leaflet_widget_library() {
 
   $libraries['leaflet_draw'] = array(
     'title' => 'Leaflet.draw',
-    'version' => '0.2.4',
+    'version' => '0.4.7',
     'css' => array(
       "$leaflet_draw/dist/leaflet.draw.css" => array(),
     ),
@@ -296,7 +296,7 @@ function leaflet_widget_library() {
   $leaflet_image_path = $leaflet_core . '/dist/images';
   $libraries['leaflet_core'] = array(
     'title' => 'Leaflet (Leaflet Widget)',
-    'version' => '0.7.3',
+    'version' => '1.0.2',
     'css' => array(
       "$leaflet_core/dist/leaflet.css" => array(),
     ),


### PR DESCRIPTION

This is being reviewed for merge as part as CIVIC-4774

h2. Description
Support multiple geo data input in the Geofield leaflet_draw widget.

Ref. NuCivic/usda-nal#596
Ref: NuCivic/usda-nal#751
Ref: NuCivic/usda-nal#752
- Follow more closely the proposed mock-ups.
- Use JQuery UI for the tabs ui.
- Sync all inputs on tab selection.

## PR dependencies
### QA only PRs
- https://github.com/NuCivic/dkan/pull/1589

### Core Dkan behat tests 
- https://github.com/NuCivic/dkan/pull/1611