### PR TITLE
Add a RESET button to the leaflet widget.

### DIFF
--- a/js/draw.js
+++ b/js/draw.js
@@ -82,6 +82,9 @@
 
               $('#' + id + '-reset-toggle').click(function () {
                 map.invalidateSize().setView(options.map['center'], options.map['zoom']);
+                leafletWidgetLayerRemove(map._layers, Items);
+                map._layers = Drupal.settings.leaflet_widget_widget[id]['orig_layers'];
+                leafletWidgetLayerAdd(map._layers, Items);
               });
 
             }
@@ -126,6 +129,8 @@
                 layers.push(geojson._layers[key]);
                }
             }
+            // Save ORIG layers to use with RESET button.
+            Drupal.settings.leaflet_widget_widget[id]['orig_layers'] = layers;
 
             var Items = new L.FeatureGroup(layers).addTo(map);
             // Autocenter if that's cool.
@@ -197,6 +202,17 @@
       for (var key in layers) {
         if (layers[key]._latlngs || layers[key]._latlng) {
           Items.removeLayer(layers[key]);
+        }
+      }
+    }
+
+    /**
+     * Add layers that are already on the map.
+     */
+    function leafletWidgetLayerAdd(layers, Items) {
+      for (var key in layers) {
+        if (layers[key]._latlngs || layers[key]._latlng) {
+          Items.addLayer(layers[key]);
         }
       }
     }

--- a/js/draw.js
+++ b/js/draw.js
@@ -11,6 +11,7 @@
             var id = $(item).attr('id'),
             options = settings.leaflet_widget_widget[id];
             if (options.toggle) {
+              $('#' + id + '-input').before('<div class="map btn btn-default" style="cursor: pointer;" id="' + id + '-reset-toggle">RESET</div>');
               $('#' + id + '-input').before('<div class="map btn btn-default" style="cursor: pointer;" id="' + id + '-geojson-toggle">GEOJSON</div>');
               $('#' + id + '-input').before('<div class="map btn btn-default" style="cursor: pointer;" id="' + id + '-point-toggle">POINT</div></br><input type="text" id="manual-' + id + '-point-input" name="manual-point">');
                 $('#manual-' + id + '-point-input').hide();
@@ -77,6 +78,10 @@
                     $('.geographic_areas_desc').show();
                   }
                 }
+              });
+
+              $('#' + id + '-reset-toggle').click(function () {
+                map.invalidateSize().setView(options.map['center'], options.map['zoom']);
               });
 
             }


### PR DESCRIPTION
Ref: nucivic/usda-nal#765

Sometimes the  widget map gets all screwed up for whatever reason.  Adding a "RESET"
button helps the user by giving her an easy way to return to the default
settings.

This issue is related to nucivic/usda-nal#765.  This commits adds a possible way
of dealing with the issue but acknowledges that there is no way for this module to implement a general
automatic fix for this problem because the module has no way of knowing how the
leaflet widget will be wrapped under all circumstances.
# Acceptance:
- [ ] Clicking "RESET" button redraws map after an unsaved change is made.
- [ ] Make change to map by adding a polygon.  Clicking "RESET" before saving node resets the original polygon.
